### PR TITLE
plugin-oauth: real-world fixes from end-to-end gdrive testing

### DIFF
--- a/cmd/daemon_core.go
+++ b/cmd/daemon_core.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -178,49 +179,26 @@ var initDaemonComponents = func(log logger.Logger, maxConcurrent int, rpcCfg *se
 		return nil, err
 	}
 
-	// Set up download queue if max-concurrent is specified
-	if maxConcurrent > 0 {
-		// onStartDownload is called by the queue when a slot becomes available
-		// for a waiting download. It auto-resumes the queued download.
-		onStartDownload := func(hash string) {
-			item := m.GetItem(hash)
-			if item == nil {
-				log.Error("Queue auto-start failed for %s: item not found", hash)
-				return
-			}
-
-			if !item.HasParts() {
-				go func() {
-					if err := item.Start(); err != nil {
-						log.Error("Queue auto-start failed for %s: %v", hash, err)
-					}
-				}()
-				log.Info("Queue auto-started download: %s", hash)
-				return
-			}
-
-			item, err := m.ResumeDownload(client, hash, nil)
-			if err != nil {
-				log.Error("Queue auto-start failed for %s: %v", hash, err)
-				return
-			}
-			// Start the download in background
-			go func() {
-				if err := item.Resume(); err != nil {
-					log.Error("Queue auto-resume failed for %s: %v", hash, err)
-				}
-			}()
-			log.Info("Queue auto-started download: %s", hash)
-		}
-		m.SetMaxConcurrentDownloads(maxConcurrent, onStartDownload)
-		log.Info("Download queue enabled: max %d concurrent", maxConcurrent)
-	}
+	// Queue setup is deferred until after the Server is constructed
+	// (below) so onStartDownload can capture the pool and broadcast
+	// errors back to any connected CLI. Wiring it before the server
+	// existed meant failures were silent: only the daemon console saw
+	// them; the CLI kept polling at 0 B/s forever.
 
 	// Create SchemeRouter for protocol dispatch (http, https, ftp, ftps)
 	router := warplib.NewSchemeRouter(client)
 	m.SetSchemeRouter(router)
 
-	// Initialize scheduler for --start-at scheduling
+	// Initialize scheduler for --start-at scheduling.
+	//
+	// schedPool is nil during startup (missed-schedule replay) and gets
+	// populated below once the server exists. Closures capture it by
+	// reference so trigger callbacks that fire AFTER the server is up
+	// will see a non-nil pool and broadcast failures to any connected
+	// CLI. Nil-safe: ReportAsyncDownloadError does nothing useful with
+	// a nil pool — we guard the call site instead of unsafely passing
+	// nil and crashing.
+	var schedPool *server.Pool
 	schedCtx, schedCancel := context.WithCancel(context.Background())
 	triggerFn := func(hash string) {
 		log.Info("Scheduler triggered download: %s", hash)
@@ -269,6 +247,9 @@ var initDaemonComponents = func(log logger.Logger, maxConcurrent int, rpcCfg *se
 			go func() {
 				if err := item.Start(); err != nil {
 					log.Error("Scheduler trigger: Start failed for %s: %v", hash, err)
+					if schedPool != nil {
+						api.ReportAsyncDownloadError(schedPool, hash, err, m)
+					}
 				}
 			}()
 			return
@@ -278,11 +259,17 @@ var initDaemonComponents = func(log logger.Logger, maxConcurrent int, rpcCfg *se
 		resumedItem, err := m.ResumeDownload(client, hash, nil)
 		if err != nil {
 			log.Error("Scheduler trigger: ResumeDownload failed for %s: %v", hash, err)
+			if schedPool != nil {
+				api.ReportAsyncDownloadError(schedPool, hash, err, m)
+			}
 			return
 		}
 		go func() {
 			if err := resumedItem.Resume(); err != nil {
 				log.Error("Scheduler trigger: Resume failed for %s: %v", hash, err)
+				if schedPool != nil {
+					api.ReportAsyncDownloadError(schedPool, hash, err, m)
+				}
 			}
 		}()
 	}
@@ -332,6 +319,55 @@ var initDaemonComponents = func(log logger.Logger, maxConcurrent int, rpcCfg *se
 	// Create server
 	serv := server.NewServer(stdLog, m, DEF_PORT, client, router, rpcCfg)
 	s.RegisterHandlers(serv)
+
+	// Now that the pool exists, wire up the queue's auto-start callback so
+	// any failure surfaces to both logs.txt (via item.Start/Resume) and
+	// the CLI (via pool.Broadcast). Without broadcasting the CLI would
+	// poll progress forever, never learning the download never actually
+	// began.
+	// Populate the late-bound scheduler pool reference so trigger
+	// callbacks firing after daemon startup can broadcast failures.
+	schedPool = serv.Pool()
+
+	if maxConcurrent > 0 {
+		pool := serv.Pool()
+		onStartDownload := func(hash string) {
+			item := m.GetItem(hash)
+			if item == nil {
+				err := fmt.Errorf("queue auto-start: item %s not found", hash)
+				log.Error("%v", err)
+				api.ReportAsyncDownloadError(pool, hash, err, m)
+				return
+			}
+
+			if !item.HasParts() {
+				go func() {
+					if err := item.Start(); err != nil {
+						log.Error("Queue auto-start failed for %s: %v", hash, err)
+						api.ReportAsyncDownloadError(pool, hash, err, m)
+					}
+				}()
+				log.Info("Queue auto-started download: %s", hash)
+				return
+			}
+
+			resumed, err := m.ResumeDownload(client, hash, nil)
+			if err != nil {
+				log.Error("Queue auto-start failed for %s: %v", hash, err)
+				api.ReportAsyncDownloadError(pool, hash, err, m)
+				return
+			}
+			go func() {
+				if err := resumed.Resume(); err != nil {
+					log.Error("Queue auto-resume failed for %s: %v", hash, err)
+					api.ReportAsyncDownloadError(pool, hash, err, m)
+				}
+			}()
+			log.Info("Queue auto-started download: %s", hash)
+		}
+		m.SetMaxConcurrentDownloads(maxConcurrent, onStartDownload)
+		log.Info("Download queue enabled: max %d concurrent", maxConcurrent)
+	}
 
 	return &DaemonComponents{
 		CookieManager:   cm,

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1601,7 +1601,7 @@ func TestStopHandlerCancelsScheduledItem(t *testing.T) {
 func TestReportAsyncDownloadError_NilError(t *testing.T) {
 	pool := server.NewPool(log.New(io.Discard, "", 0))
 	// Must not panic and must be a no-op for nil error
-	reportAsyncDownloadError(pool, "uid-1", nil)
+	ReportAsyncDownloadError(pool, "uid-1", nil, nil)
 }
 
 func TestReportAsyncDownloadError_WithError(t *testing.T) {
@@ -1609,7 +1609,7 @@ func TestReportAsyncDownloadError_WithError(t *testing.T) {
 	// With a real error the function broadcasts and stops the download.
 	// The pool has no active download registered so StopDownload is a no-op,
 	// but calling through the full path covers the three statements.
-	reportAsyncDownloadError(pool, "uid-2", errors.New("async failure"))
+	ReportAsyncDownloadError(pool, "uid-2", errors.New("async failure"), nil)
 }
 
 func TestStopHandlerCancelsRecurringItem(t *testing.T) {

--- a/internal/api/async_error_test.go
+++ b/internal/api/async_error_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/warpdl/warpdl/internal/server"
+	"github.com/warpdl/warpdl/pkg/warplib"
+)
+
+// ReportAsyncDownloadError is the seam daemon-side code (queue auto-start,
+// scheduler) uses to surface async errors to the CLI. This test locks in
+// the three things it MUST do: broadcast an InitError frame on the pool,
+// record a critical error keyed by uid, and stop the download. Without
+// all three the CLI polls forever showing 0 B/s.
+func TestReportAsyncDownloadError_BroadcastsStopsAndRecords(t *testing.T) {
+	p := server.NewPool(nil)
+	// Wire a subscriber to the broadcast.
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	sconn := server.NewSyncConn(c1)
+	p.AddDownload("hash1", sconn)
+
+	type readResult struct {
+		msg []byte
+		err error
+	}
+	peer := server.NewSyncConn(c2)
+	ch := make(chan readResult, 1)
+	go func() {
+		msg, err := peer.Read()
+		ch <- readResult{msg, err}
+	}()
+
+	ReportAsyncDownloadError(p, "hash1", errors.New("file already exists"), nil)
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("peer read err: %v", r.err)
+		}
+		if len(r.msg) == 0 {
+			t.Fatal("broadcast payload empty")
+		}
+		if !contains(r.msg, "file already exists") {
+			t.Fatalf("broadcast missing underlying error: %s", r.msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no broadcast within 1s")
+	}
+
+	rec := p.GetError("hash1")
+	if rec == nil {
+		t.Fatal("expected recorded error on pool")
+	}
+	if rec.Message != "file already exists" {
+		t.Errorf("recorded message = %q, want %q", rec.Message, "file already exists")
+	}
+	if rec.Type != server.ErrorTypeCritical {
+		t.Errorf("recorded type = %v, want Critical", rec.Type)
+	}
+}
+
+// A failed download that never wrote a byte must be purged from the
+// manager when ReportAsyncDownloadError is invoked with a non-nil
+// manager. This is the "don't pollute history with ghost rows"
+// behaviour the user asked for: retry of a failed download shouldn't
+// accumulate "(1)" / "(2)" entries in the history.
+func TestReportAsyncDownloadError_PurgesZeroByteFailure(t *testing.T) {
+	// Real httptest server so NewDownloader succeeds and we can attach
+	// a real *Downloader to the manager. The download is never started,
+	// so item.Downloaded stays 0 — exactly the case we want to purge.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5")
+		w.Header().Set("Content-Disposition", `attachment; filename="x.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	if err := warplib.SetConfigDir(configDir); err != nil {
+		t.Fatalf("SetConfigDir: %v", err)
+	}
+	mgr, err := warplib.InitManager()
+	if err != nil {
+		t.Fatalf("InitManager: %v", err)
+	}
+	defer mgr.Close()
+
+	d, err := warplib.NewDownloader(srv.Client(), srv.URL, &warplib.DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if err := mgr.AddDownload(d, &warplib.AddDownloadOpts{AbsoluteLocation: t.TempDir()}); err != nil {
+		t.Fatalf("AddDownload: %v", err)
+	}
+	hash := d.GetHash()
+	if mgr.GetItem(hash) == nil {
+		t.Fatal("setup: expected item to be in manager")
+	}
+
+	pool := server.NewPool(nil)
+	ReportAsyncDownloadError(pool, hash, errors.New("simulated start failure"), mgr)
+
+	if got := mgr.GetItem(hash); got != nil {
+		t.Fatalf("zero-byte failure must purge from history; got %+v", got)
+	}
+}
+
+// Mid-download failures (Downloaded > 0) must be KEPT so the user can
+// resume. Regression guard against an over-eager purge.
+func TestReportAsyncDownloadError_KeepsPartialDownload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.Header().Set("Content-Disposition", `attachment; filename="y.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, 100))
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	if err := warplib.SetConfigDir(configDir); err != nil {
+		t.Fatalf("SetConfigDir: %v", err)
+	}
+	mgr, err := warplib.InitManager()
+	if err != nil {
+		t.Fatalf("InitManager: %v", err)
+	}
+	defer mgr.Close()
+
+	d, err := warplib.NewDownloader(srv.Client(), srv.URL, &warplib.DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if err := mgr.AddDownload(d, &warplib.AddDownloadOpts{AbsoluteLocation: t.TempDir()}); err != nil {
+		t.Fatalf("AddDownload: %v", err)
+	}
+	hash := d.GetHash()
+	// Simulate that some bytes were downloaded before the failure.
+	item := mgr.GetItem(hash)
+	if item == nil {
+		t.Fatal("setup: expected item")
+	}
+	item.Downloaded = 42
+	mgr.UpdateItem(item)
+
+	pool := server.NewPool(nil)
+	ReportAsyncDownloadError(pool, hash, errors.New("network died mid-download"), mgr)
+
+	got := mgr.GetItem(hash)
+	if got == nil {
+		t.Fatal("partial download should NOT be purged from history")
+	}
+	if got.Downloaded != 42 {
+		t.Errorf("Downloaded = %d, want 42 (preserved)", got.Downloaded)
+	}
+}
+
+// A nil err must be a no-op — don't pollute the pool with empty errors
+// if a caller accidentally invokes the reporter in a success path.
+func TestReportAsyncDownloadError_NilIsNoop(t *testing.T) {
+	p := server.NewPool(nil)
+	ReportAsyncDownloadError(p, "hash1", nil, nil)
+	if rec := p.GetError("hash1"); rec != nil {
+		t.Fatalf("nil err should not record: %+v", rec)
+	}
+}
+
+func contains(haystack []byte, needle string) bool {
+	return indexOf(string(haystack), needle) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -38,6 +38,20 @@ func (s *Api) downloadHandler(sconn *server.SyncConn, pool *server.Pool, body js
 		pluginHeaders = append(pluginHeaders, warplib.Header{Key: k, Value: v})
 	}
 
+	// If the user did NOT pass -o/--filename but the plugin supplied a
+	// filename hint (e.g. Drive's files.get?fields=name result), use it.
+	// User intent always wins over plugin hints.
+	//
+	// userExplicitFileName is captured BEFORE the plugin fallback so the
+	// downloader knows whether to lock the name (user-chosen, error on
+	// collision) or auto-rename it browser-style (URL/plugin-derived,
+	// rename to "foo (1).pdf" so a retry of a failed download isn't
+	// blocked by the leftover stub).
+	userExplicitFileName := m.FileName != ""
+	if m.FileName == "" && extRes.FileName != "" {
+		m.FileName = extRes.FileName
+	}
+
 	// Detect scheme to choose code path
 	parsed, parseErr := url.Parse(dlURL)
 	if parseErr != nil {
@@ -49,24 +63,52 @@ func (s *Api) downloadHandler(sconn *server.SyncConn, pool *server.Pool, body js
 	case "ftp", "ftps", "sftp":
 		return s.downloadProtocolHandler(sconn, pool, dlURL, scheme, &m)
 	default:
-		return s.downloadHTTPHandler(sconn, pool, dlURL, &m, pluginHeaders)
+		return s.downloadHTTPHandler(sconn, pool, dlURL, &m, pluginHeaders, userExplicitFileName)
 	}
 }
 
-func reportAsyncDownloadError(pool *server.Pool, uid string, err error) {
+// ReportAsyncDownloadError pushes an async-path error (queue auto-start
+// failure, scheduler trigger failure, goroutine panic) through the pool
+// so any connected CLI sees an InitError broadcast and Stop event
+// instead of polling progress forever.
+//
+// When mgr is non-nil and the failed download never wrote a byte
+// (item.Downloaded == 0), the manager entry is purged. Rationale: a
+// download that died before writing anything has no resume state and
+// no completed bytes — leaving it in history is noise that accumulates
+// every retry. Mid-download failures (nread > 0) are kept so the user
+// can resume.
+//
+// Exported for daemon wiring (queue, scheduler).
+func ReportAsyncDownloadError(pool *server.Pool, uid string, err error, mgr *warplib.Manager) {
 	if err == nil {
 		return
 	}
 	pool.Broadcast(uid, server.InitError(err))
 	pool.WriteError(uid, server.ErrorTypeCritical, err.Error())
 	pool.StopDownload(uid)
+	if mgr != nil {
+		if item := mgr.GetItem(uid); item != nil && item.Downloaded == 0 {
+			_ = mgr.PurgeFailedDownload(uid)
+		}
+	}
+}
+
+// reportAsyncDownloadError is the api-internal helper that wraps
+// ReportAsyncDownloadError with the api's manager so zero-byte
+// failures are also purged from history.
+func (s *Api) reportAsyncDownloadError(pool *server.Pool, uid string, err error) {
+	ReportAsyncDownloadError(pool, uid, err, s.manager)
 }
 
 // downloadHTTPHandler handles HTTP and HTTPS downloads.
 // pluginHeaders carries headers sourced from a plugin's extract() result;
 // they are routed through DownloaderOpts.PluginHeaders so the downloader
 // strips them on cross-origin redirects (Task 19).
-func (s *Api) downloadHTTPHandler(sconn *server.SyncConn, pool *server.Pool, dlURL string, m *common.DownloadParams, pluginHeaders warplib.Headers) (common.UpdateType, any, error) {
+// userExplicitFileName is true when the user passed --filename on the CLI
+// (vs. a name supplied by a plugin or derived from the URL); the
+// downloader uses it to decide whether to auto-rename on collision.
+func (s *Api) downloadHTTPHandler(sconn *server.SyncConn, pool *server.Pool, dlURL string, m *common.DownloadParams, pluginHeaders warplib.Headers, userExplicitFileName bool) (common.UpdateType, any, error) {
 	// Determine which client to use based on proxy setting
 	dlClient := s.client
 	if m.Proxy != "" {
@@ -143,6 +185,7 @@ func (s *Api) downloadHTTPHandler(sconn *server.SyncConn, pool *server.Pool, dlU
 	d, err = warplib.NewDownloader(dlClient, dlURL, &warplib.DownloaderOpts{
 		Headers:           m.Headers,
 		PluginHeaders:     pluginHeaders,
+		LockFileName:      userExplicitFileName,
 		ForceParts:        m.ForceParts,
 		FileName:          m.FileName,
 		DownloadDirectory: m.DownloadDirectory,
@@ -328,7 +371,7 @@ func (s *Api) downloadHTTPHandler(sconn *server.SyncConn, pool *server.Pool, dlU
 	if s.manager.GetQueue() == nil {
 		go func() {
 			if err := d.Start(); err != nil {
-				reportAsyncDownloadError(pool, d.GetHash(), err)
+				s.reportAsyncDownloadError(pool, d.GetHash(), err)
 				_ = d.Close()
 			}
 		}()
@@ -442,7 +485,7 @@ func (s *Api) downloadProtocolHandler(sconn *server.SyncConn, pool *server.Pool,
 	if s.manager.GetQueue() == nil {
 		go func() {
 			if err := pd.Download(context.Background(), handlers); err != nil {
-				reportAsyncDownloadError(pool, pd.GetHash(), err)
+				s.reportAsyncDownloadError(pool, pd.GetHash(), err)
 				_ = pd.Close()
 			}
 		}()

--- a/internal/extl/auth/manifest.go
+++ b/internal/extl/auth/manifest.go
@@ -6,10 +6,17 @@ import (
 )
 
 // OAuth2Config is the `auth` block of a plugin manifest.
+//
+// ClientSecret is optional. Some IdPs — notably Google's "Desktop app"
+// OAuth client type — still require the client_secret field on /token
+// requests even though the app is a public (PKCE) client. In that case
+// the secret is embedded in the distributed plugin and is not
+// cryptographically secret. Plugins that can rely on pure PKCE should
+// leave this empty.
 type OAuth2Config struct {
 	Type            string            `json:"type"`
 	ClientID        string            `json:"client_id"`
-	ClientSecret    string            `json:"client_secret,omitempty"` // REJECTED; kept for friendly error
+	ClientSecret    string            `json:"client_secret,omitempty"`
 	Scopes          []string          `json:"scopes"`
 	AuthorizeURL    string            `json:"authorize_url"`
 	TokenURL        string            `json:"token_url"`
@@ -26,10 +33,6 @@ func ValidateOAuth2Config(cfg OAuth2Config) error {
 	}
 	if cfg.Type != "oauth2" {
 		return fmt.Errorf("auth: only type \"oauth2\" is supported (got %q)", cfg.Type)
-	}
-	if cfg.ClientSecret != "" {
-		return fmt.Errorf("auth: client_secret is not supported " +
-			"(PKCE public clients only). Remove client_secret from the manifest.")
 	}
 	if cfg.ClientID == "" {
 		return fmt.Errorf("auth: client_id is required")

--- a/internal/extl/auth/manifest_test.go
+++ b/internal/extl/auth/manifest_test.go
@@ -22,6 +22,14 @@ func TestValidateMinimal(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsOptionalClientSecret(t *testing.T) {
+	c := validCfg()
+	c.ClientSecret = "GOCSPX-embedded-secret"
+	if err := ValidateOAuth2Config(c); err != nil {
+		t.Fatalf("config with client_secret rejected: %v", err)
+	}
+}
+
 func TestValidateDefaultsPKCE(t *testing.T) {
 	c := validCfg()
 	c.PKCEMethod = ""
@@ -51,7 +59,6 @@ func TestValidateRejectsCases(t *testing.T) {
 		{"https no host", func(c *OAuth2Config) { c.AuthorizeURL = "https://" }, "missing host"},
 		{"https opaque", func(c *OAuth2Config) { c.AuthorizeURL = "https:example.com" }, "missing host"},
 		{"bad pkce", func(c *OAuth2Config) { c.PKCEMethod = "wat" }, "pkce"},
-		{"forbidden secret", func(c *OAuth2Config) { c.ClientSecret = "s" }, "client_secret"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/extl/auth/oauth2.go
+++ b/internal/extl/auth/oauth2.go
@@ -237,6 +237,13 @@ func (p *OAuth2Provider) muFor(key types.TokenKey) *sync.Mutex {
 }
 
 func (p *OAuth2Provider) postToken(ctx context.Context, form url.Values, prior *types.OAuth2Token) (*types.OAuth2Token, error) {
+	// Some IdPs (e.g. Google Desktop-app clients) require the client_secret
+	// on /token even though the app uses PKCE. Include it when the manifest
+	// declares one. Pure PKCE public clients leave it empty and it stays
+	// out of the form.
+	if p.cfg.ClientSecret != "" && form.Get("client_secret") == "" {
+		form.Set("client_secret", p.cfg.ClientSecret)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.cfg.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, err

--- a/internal/extl/auth/oauth2_test.go
+++ b/internal/extl/auth/oauth2_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,8 @@ type stubIdP struct {
 	lastCode         string
 	lastVerifier     string
 	lastRefreshToken string
+	lastClientID     string
+	lastClientSecret string
 }
 
 func newStubIdP(t *testing.T, access, refresh string, expiresIn int) *stubIdP {
@@ -38,6 +41,8 @@ func newStubIdP(t *testing.T, access, refresh string, expiresIn int) *stubIdP {
 		s.lastCode = r.FormValue("code")
 		s.lastVerifier = r.FormValue("code_verifier")
 		s.lastRefreshToken = r.FormValue("refresh_token")
+		s.lastClientID = r.FormValue("client_id")
+		s.lastClientSecret = r.FormValue("client_secret")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  access,
 			"refresh_token": refresh,
@@ -61,6 +66,10 @@ func newInsecureTLSClient() *http.Client {
 }
 
 func makeTestProvider(t *testing.T, tokenURL, revokeURL string) (*OAuth2Provider, *credman.TokenManager) {
+	return makeTestProviderWithSecret(t, tokenURL, revokeURL, "")
+}
+
+func makeTestProviderWithSecret(t *testing.T, tokenURL, revokeURL, clientSecret string) (*OAuth2Provider, *credman.TokenManager) {
 	t.Helper()
 	key := make([]byte, 32)
 	_, _ = rand.Read(key)
@@ -72,6 +81,7 @@ func makeTestProvider(t *testing.T, tokenURL, revokeURL string) (*OAuth2Provider
 	cfg := OAuth2Config{
 		Type:         "oauth2",
 		ClientID:     "client-id",
+		ClientSecret: clientSecret,
 		Scopes:       []string{"drive.readonly"},
 		AuthorizeURL: "https://example.com/authorize",
 		TokenURL:     tokenURL,
@@ -508,5 +518,146 @@ func TestDeviceCodeFlow(t *testing.T) {
 	}
 	if tokenCalls.Load() < 3 {
 		t.Fatalf("expected 3 polls, got %d", tokenCalls.Load())
+	}
+}
+
+// Google Desktop-app OAuth clients require client_secret on /token even
+// though the flow is PKCE. Regression test for the "client_secret is
+// missing" rejection from Google's token endpoint.
+func TestExchangeCodeSendsClientSecretWhenConfigured(t *testing.T) {
+	idp := newStubIdP(t, "AT1", "RT1", 3600)
+	p, _ := makeTestProviderWithSecret(t, idp.server.URL+"/token", "", "GOCSPX-test-secret")
+	verifier, _ := NewPKCEVerifier()
+	if _, err := p.ExchangeCode(context.Background(), types.TokenKey{PluginID: "plugin-1"}, "CODE", verifier, "http://127.0.0.1/cb"); err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if idp.lastClientID != "client-id" {
+		t.Fatalf("client_id = %q", idp.lastClientID)
+	}
+	if idp.lastClientSecret != "GOCSPX-test-secret" {
+		t.Fatalf("client_secret not sent: got %q", idp.lastClientSecret)
+	}
+}
+
+// When the manifest supplies no client_secret, pure PKCE must stay pure —
+// never inject anything into the form.
+func TestExchangeCodeOmitsClientSecretByDefault(t *testing.T) {
+	idp := newStubIdP(t, "AT1", "RT1", 3600)
+	p, _ := makeTestProvider(t, idp.server.URL+"/token", "")
+	verifier, _ := NewPKCEVerifier()
+	if _, err := p.ExchangeCode(context.Background(), types.TokenKey{PluginID: "plugin-1"}, "CODE", verifier, "http://127.0.0.1/cb"); err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if idp.lastClientSecret != "" {
+		t.Fatalf("client_secret leaked into PKCE flow: %q", idp.lastClientSecret)
+	}
+}
+
+// Refresh grant must also carry client_secret; Google's /token rejects
+// refresh_token grants from Desktop clients without it.
+func TestRefreshSendsClientSecretWhenConfigured(t *testing.T) {
+	idp := newStubIdP(t, "AT-REFRESHED", "RT-ROTATED", 3600)
+	p, tm := makeTestProviderWithSecret(t, idp.server.URL+"/token", "", "GOCSPX-test-secret")
+	key := types.TokenKey{PluginID: "plugin-1"}
+	_ = tm.Set(key, &types.OAuth2Token{
+		AccessToken:  "OLD",
+		RefreshToken: "RT-OLD",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+		Scopes:       []string{"drive.readonly"},
+	})
+	if _, err := p.Token(context.Background(), key, []string{"drive.readonly"}); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if idp.lastGrant != "refresh_token" {
+		t.Fatalf("grant_type = %q", idp.lastGrant)
+	}
+	if idp.lastClientSecret != "GOCSPX-test-secret" {
+		t.Fatalf("client_secret not sent on refresh: got %q", idp.lastClientSecret)
+	}
+}
+
+// Device-code grant (RFC 8628) runs through postToken too; client_secret
+// must be included when configured.
+func TestDeviceCodeGrantSendsClientSecretWhenConfigured(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var seenSecret atomic.Value
+	seenSecret.Store("")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device/code", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "DEVICE-CODE-123",
+			"user_code":        "ABCD-1234",
+			"verification_url": "https://example.com/device",
+			"expires_in":       600,
+			"interval":         1,
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		seenSecret.Store(r.FormValue("client_secret"))
+		tokenCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "DEV-AT",
+			"refresh_token": "DEV-RT",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"scope":         "drive.readonly",
+		})
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+	tm, _ := credman.NewTokenManager(filepath.Join(t.TempDir(), "tokens.gob"), key)
+	defer tm.Close()
+	cfg := OAuth2Config{
+		Type:         "oauth2",
+		ClientID:     "c",
+		ClientSecret: "GOCSPX-device-secret",
+		Scopes:       []string{"drive.readonly"},
+		AuthorizeURL: "https://example.com/authorize",
+		TokenURL:     srv.URL + "/token",
+		DeviceURL:    srv.URL + "/device/code",
+		PKCEMethod:   "S256",
+	}
+	cfg, _ = NormalizeOAuth2Config(cfg)
+	p := NewOAuth2Provider("pid", cfg, tm, NewFlowRegistry(time.Minute))
+	p.client = newInsecureTLSClient()
+
+	init, err := p.StartDeviceCode(context.Background())
+	if err != nil {
+		t.Fatalf("StartDeviceCode: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := p.PollDeviceCode(ctx, init); err != nil {
+		t.Fatalf("PollDeviceCode: %v", err)
+	}
+	if got := seenSecret.Load().(string); got != "GOCSPX-device-secret" {
+		t.Fatalf("client_secret not sent on device_code grant: got %q", got)
+	}
+	if tokenCalls.Load() == 0 {
+		t.Fatal("/token never called")
+	}
+}
+
+// A caller that has already set client_secret on the form (future-proof
+// against exotic grants) must not be overwritten by the manifest's value.
+func TestPostTokenPreservesExplicitClientSecret(t *testing.T) {
+	idp := newStubIdP(t, "AT", "", 3600)
+	p, _ := makeTestProviderWithSecret(t, idp.server.URL+"/token", "", "MANIFEST-SECRET")
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "x")
+	form.Set("redirect_uri", "http://127.0.0.1/cb")
+	form.Set("client_id", "client-id")
+	form.Set("code_verifier", "verifier")
+	form.Set("client_secret", "EXPLICIT-SECRET")
+	if _, err := p.postToken(context.Background(), form, nil); err != nil {
+		t.Fatalf("postToken: %v", err)
+	}
+	if idp.lastClientSecret != "EXPLICIT-SECRET" {
+		t.Fatalf("caller-provided client_secret clobbered: got %q", idp.lastClientSecret)
 	}
 }

--- a/internal/extl/extl_test.go
+++ b/internal/extl/extl_test.go
@@ -332,6 +332,71 @@ func TestModuleLoadErrors(t *testing.T) {
 	}
 }
 
+// A plugin may return {url, headers, filename}. The filename flows
+// through ExtractResult.FileName so download.go can use it as a hint
+// when the user didn't pass -o and the server doesn't send
+// Content-Disposition (e.g. Drive API /alt=media).
+func TestModuleExtractPropagatesFileName(t *testing.T) {
+	modDir := writeModuleWithMain(t, t.TempDir(), "main.js",
+		`function extract(u){ return {url: u, filename: "My Real File.pdf", headers: {"Authorization":"Bearer X"}}; }`)
+	m, err := OpenModule(log.New(io.Discard, "", 0), modDir)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	if err := m.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	res, err := m.Extract("http://example.com")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if res.FileName != "My Real File.pdf" {
+		t.Errorf("FileName = %q, want %q", res.FileName, "My Real File.pdf")
+	}
+	if res.Headers["Authorization"] != "Bearer X" {
+		t.Errorf("header lost: %#v", res.Headers)
+	}
+}
+
+// A non-string filename must be rejected to keep the contract tight.
+func TestModuleExtractRejectsNonStringFileName(t *testing.T) {
+	modDir := writeModuleWithMain(t, t.TempDir(), "main.js",
+		`function extract(u){ return {url: u, filename: 42}; }`)
+	m, err := OpenModule(log.New(io.Discard, "", 0), modDir)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	if err := m.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := m.Extract("http://example.com"); err != ErrInvalidReturnType {
+		t.Fatalf("expected ErrInvalidReturnType, got %v", err)
+	}
+}
+
+// Omitting filename must not fail — FileName is optional.
+func TestModuleExtractFileNameOptional(t *testing.T) {
+	modDir := writeModuleWithMain(t, t.TempDir(), "main.js",
+		`function extract(u){ return {url: u}; }`)
+	m, err := OpenModule(log.New(io.Discard, "", 0), modDir)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	if err := m.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	res, err := m.Extract("http://example.com")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if res.FileName != "" {
+		t.Errorf("FileName = %q, want empty", res.FileName)
+	}
+	if res.URL != "http://example.com" {
+		t.Errorf("URL round-trip lost: %q", res.URL)
+	}
+}
+
 func TestModuleExtractErrors(t *testing.T) {
 	modDir := writeModuleWithMain(t, t.TempDir(), "main.js", "function extract(url){ return 1; }\n")
 	m, err := OpenModule(log.New(io.Discard, "", 0), modDir)

--- a/internal/extl/module.go
+++ b/internal/extl/module.go
@@ -132,9 +132,10 @@ func (m *Module) Load() error {
 
 // ExtractResult is the structured return value of a plugin's extract()
 // function. Plugins may return either a plain URL string (legacy
-// contract) or a {url, headers} object — both produce an ExtractResult.
-// Future-compatible: additional optional fields (cookies, method, body)
-// can be added here without breaking string-return plugins.
+// contract) or a {url, headers, filename} object — both produce an
+// ExtractResult. Future-compatible: additional optional fields
+// (cookies, method, body) can be added here without breaking
+// string-return plugins.
 type ExtractResult struct {
 	// URL is the resolved/transformed download URL.
 	URL string
@@ -142,6 +143,11 @@ type ExtractResult struct {
 	// fetching URL. May be nil or empty. Plugins return these as a flat
 	// {string: string} object in JS; non-string values are rejected.
 	Headers map[string]string
+	// FileName is an optional filename hint. When non-empty, the
+	// downloader prefers it over the URL-derived name and over
+	// Content-Disposition. Useful for APIs (e.g. Google Drive's
+	// /files/<id>?alt=media) that stream bytes without a C-D header.
+	FileName string
 }
 
 // Extract invokes the module's JavaScript extract function with the
@@ -185,7 +191,15 @@ func (m *Module) Extract(url string) (ExtractResult, error) {
 				headers[k] = s
 			}
 		}
-		return ExtractResult{URL: rawURL, Headers: headers}, nil
+		var filename string
+		if raw, ok := x["filename"]; ok && raw != nil {
+			s, sok := raw.(string)
+			if !sok {
+				return ExtractResult{}, ErrInvalidReturnType
+			}
+			filename = s
+		}
+		return ExtractResult{URL: rawURL, Headers: headers, FileName: filename}, nil
 	default:
 		return ExtractResult{}, ErrInvalidReturnType
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,6 +49,14 @@ func (s *Server) RegisterHandler(method common.UpdateType, handler HandlerFunc) 
 	s.handler[method] = handler
 }
 
+// Pool returns the server's download pool. Exposed so daemon code can
+// broadcast error events on async paths (e.g. queue auto-start failures)
+// that would otherwise only log to the daemon console and leave the CLI
+// polling forever.
+func (s *Server) Pool() *Pool {
+	return s.pool
+}
+
 // Start begins listening for incoming connections and blocks until the context is canceled.
 // It first starts the web server in a separate goroutine, then creates a platform-specific
 // listener (Unix socket/named pipe with TCP fallback) and accepts connections in a loop.

--- a/pkg/warplib/dloader.go
+++ b/pkg/warplib/dloader.go
@@ -70,6 +70,10 @@ type Downloader struct {
 	// plugin did not anticipate. Set only when opts.PluginHeaders was
 	// populated; nil means no plugin headers.
 	pluginHeaderNames map[string]struct{}
+	// lockFileName, when true, disables auto-rename on collision. Mirrors
+	// DownloaderOpts.LockFileName so the runtime can decide policy in
+	// fetchInfo / openFile.
+	lockFileName bool
 	// total downloaded bytes
 	nread int64
 	// dlPath is the path where the downloaded content
@@ -160,8 +164,18 @@ type DownloaderOpts struct {
 	RetryConfig *RetryConfig
 
 	// Overwrite allows replacing an existing file at the destination path.
-	// If false and the file exists, the download will fail with ErrFileExists.
+	// If false and the file exists, the download will be auto-renamed
+	// browser-style (foo.pdf -> foo (1).pdf) UNLESS LockFileName is set,
+	// in which case the download fails with ErrFileExists.
 	Overwrite bool
+
+	// LockFileName disables auto-rename on collision. Set this when the
+	// caller (typically the user passing -o/--filename on the CLI)
+	// supplied an explicit filename that must not be silently changed.
+	// Plugin-supplied filename hints leave this false so a retry of a
+	// previous failed download falls back to "name (1).ext" instead of
+	// erroring out.
+	LockFileName bool
 
 	// ProxyURL specifies the proxy server URL to use for the download.
 	// Supported schemes: http, https, socks5.
@@ -265,6 +279,7 @@ func NewDownloader(client *http.Client, url string, opts *DownloaderOpts, optFun
 		maxParts:           opts.MaxSegments,
 		headers:            opts.Headers,
 		pluginHeaderNames:  pluginHeaderNames,
+		lockFileName:       opts.LockFileName,
 		resumable:          true,
 		retryConfig:        retryConfig,
 		overwrite:          opts.Overwrite,
@@ -416,6 +431,15 @@ func initDownloader(client *http.Client, hash, url string, cLength ContentLength
 // until the downloading is complete.
 func (d *Downloader) Start() (err error) {
 	defer d.lw.Close()
+	// Log every exit path on error so logs.txt tells the same story the
+	// caller sees. Without this, a failed openFile / disk check / etc.
+	// left logs.txt with only the init lines and the user had to chase
+	// the daemon console to find out why their download never started.
+	defer func() {
+		if err != nil {
+			d.Log("Start failed: %v", err)
+		}
+	}()
 	err = d.openFile()
 	if err != nil {
 		return
@@ -502,6 +526,11 @@ func (d *Downloader) Start() (err error) {
 // It blocks the current goroutine until the download is complete.
 func (d *Downloader) Resume(parts map[int64]*ItemPart) (err error) {
 	defer d.lw.Close()
+	defer func() {
+		if err != nil {
+			d.Log("Resume failed: %v", err)
+		}
+	}()
 	if parts == nil {
 		return errors.New("invalid or uninitialized parts; cannot resume download")
 	}
@@ -1214,7 +1243,14 @@ func (d *Downloader) IsStopped() bool {
 
 // Log adds the provided string to download's log file.
 // It can't be used once download is complete.
+// Safe on a Downloader whose logger was never initialised (e.g. when
+// Start/Resume exits very early before setupLogger ran, or in tests
+// that skip full setup) — the call becomes a no-op instead of a nil
+// pointer panic.
 func (d *Downloader) Log(s string, a ...any) {
+	if d == nil || d.l == nil {
+		return
+	}
 	wlog(d.l, s, a...)
 }
 
@@ -1331,6 +1367,50 @@ func (d *Downloader) checkContentType(h *http.Header) (err error) {
 	return
 }
 
+// httpErrorBodyPeek bounds how much of a 4xx/5xx response body we pull
+// into the error message. Just enough to surface a useful server
+// message ("Drive API not enabled", "invalid_token", ...) without
+// flooding terminals when the server streams a huge error HTML page.
+const httpErrorBodyPeek = 2048
+
+// HTTPStatusError is returned by fetchInfo when the server responds
+// with a non-success status for the initial download request. Callers
+// can test with errors.As / errors.Is to distinguish "network is fine,
+// server rejected us" from transport errors.
+type HTTPStatusError struct {
+	StatusCode int
+	Status     string
+	URL        string
+	Snippet    string // first few KB of body, trimmed
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Snippet == "" {
+		return fmt.Sprintf("HTTP %s for %s", e.Status, e.URL)
+	}
+	return fmt.Sprintf("HTTP %s for %s: %s", e.Status, e.URL, e.Snippet)
+}
+
+func newHTTPStatusError(resp *http.Response) *HTTPStatusError {
+	e := &HTTPStatusError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+	}
+	if resp.Request != nil && resp.Request.URL != nil {
+		e.URL = resp.Request.URL.String()
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, httpErrorBodyPeek+1))
+	snippet := string(bytes.TrimSpace(body))
+	if len(snippet) > httpErrorBodyPeek {
+		snippet = snippet[:httpErrorBodyPeek] + "…"
+	}
+	// Collapse runs of whitespace so multi-line HTML/JSON error pages
+	// don't blow up the CLI output.
+	snippet = strings.Join(strings.Fields(snippet), " ")
+	e.Snippet = snippet
+	return e
+}
+
 // fetchInfo fetches the information about the file to be downloaded.
 // It sets the content length, file name, and prepares the downloader.
 // After the initial request, if the URL was redirected, d.url is updated
@@ -1343,6 +1423,15 @@ func (d *Downloader) fetchInfo() (err error) {
 		return
 	}
 	defer resp.Body.Close()
+
+	// Guard: if the server returned a non-2xx/3xx the body is almost
+	// certainly an error page or JSON, not the file. Treating it as file
+	// content (as we used to) saves nonsense to disk and hides whatever
+	// the server actually said. Surface the status + a body excerpt so
+	// the user sees the real message (e.g. "Drive API not enabled").
+	if resp.StatusCode >= 400 {
+		return newHTTPStatusError(resp)
+	}
 
 	// Update URL to final resolved URL after any redirect chain.
 	// This ensures all subsequent Range requests (parallel segments)
@@ -1377,6 +1466,21 @@ func (d *Downloader) fetchInfo() (err error) {
 	err = d.setFileName(resp.Request, &h)
 	if err != nil {
 		return
+	}
+
+	// Auto-rename on destination collision (browser-style: "name (1).ext")
+	// so a retry of a previously-failed download doesn't get blocked by
+	// the leftover stub file. Skipped when:
+	//   - the user explicitly chose --overwrite (their intent wins)
+	//   - the user explicitly named the file via --filename (LockFileName)
+	// In LockFileName mode the collision will surface later from
+	// openFile() as ErrFileExists, matching previous behaviour exactly.
+	if !d.overwrite && !d.lockFileName && d.fileName != "" {
+		candidate := GetPath(d.dlLoc, d.fileName)
+		uniq, uerr := uniquifyPath(candidate)
+		if uerr == nil && uniq != candidate {
+			d.fileName = filepath.Base(uniq)
+		}
 	}
 
 	// Extract checksums from response headers

--- a/pkg/warplib/http_status_test.go
+++ b/pkg/warplib/http_status_test.go
@@ -1,0 +1,179 @@
+package warplib
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNewDownloaderRejectsForbidden exercises the regression that prompted
+// this guard: Google Drive API returned 403 JSON ("Drive API not enabled"),
+// warpdl treated it as a 2KB file, and saved the error body to disk under
+// a URL-derived filename. After the fix, fetchInfo must surface the status
+// and body snippet as an *HTTPStatusError and must not create any file.
+func TestNewDownloaderRejectsForbidden(t *testing.T) {
+	const errBody = `{"error":{"code":403,"message":"Google Drive API has not been used in project 12345 before or it is disabled."}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(errBody))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: dir,
+		FileName:          "should-not-appear.bin",
+	})
+	if d != nil {
+		defer d.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error from fetchInfo for 403 response, got nil")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPStatusError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want 403", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Snippet, "Drive API has not been used") {
+		t.Errorf("Snippet missing server message: %q", httpErr.Snippet)
+	}
+
+	// Most important assertion: nothing was saved to disk.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		t.Errorf("fetchInfo leaked file into download dir: %s", filepath.Join(dir, e.Name()))
+	}
+}
+
+// A 4xx body longer than the peek limit must be truncated (and marked
+// with an ellipsis) so the error message stays bounded even when the
+// server streams a giant HTML error page.
+func TestHTTPStatusErrorTruncatesLongBody(t *testing.T) {
+	huge := strings.Repeat("x", httpErrorBodyPeek*4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+		FileName:          "x",
+	})
+	if d != nil {
+		defer d.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPStatusError, got %T", err)
+	}
+	// Snippet must be capped: original body + ellipsis byte.
+	if ln := len(httpErr.Snippet); ln > httpErrorBodyPeek+10 {
+		t.Errorf("snippet too long: %d bytes", ln)
+	}
+	if !strings.HasSuffix(httpErr.Snippet, "…") {
+		t.Errorf("expected ellipsis to mark truncation, got tail %q", tail(httpErr.Snippet, 8))
+	}
+}
+
+// An empty 4xx body must still produce a useful error.
+func TestHTTPStatusErrorEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+		FileName:          "x",
+	})
+	if d != nil {
+		defer d.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPStatusError, got %T", err)
+	}
+	if httpErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want 401", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Error(), "401") {
+		t.Errorf("error message missing status: %q", httpErr.Error())
+	}
+}
+
+// Regression guard: 2xx responses must behave exactly as before — no
+// early return, normal download path.
+func TestNewDownloaderAcceptsSuccessStatus(t *testing.T) {
+	body := []byte("hello")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5")
+		w.Header().Set("Content-Disposition", `attachment; filename="hi.txt"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("200 response should not error: %v", err)
+	}
+	defer d.Close()
+	if d.GetFileName() != "hi.txt" {
+		t.Errorf("filename = %q, want hi.txt", d.GetFileName())
+	}
+}
+
+// 3xx redirects are followed by net/http; fetchInfo only sees the final
+// response. If that final response is 4xx the guard must still fire.
+func TestNewDownloaderRejects4xxAfterRedirect(t *testing.T) {
+	srv404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusNotFound)
+	}))
+	defer srv404.Close()
+	srvRedir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv404.URL, http.StatusFound)
+	}))
+	defer srvRedir.Close()
+
+	d, err := NewDownloader(srvRedir.Client(), srvRedir.URL, &DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+		FileName:          "x",
+	})
+	if d != nil {
+		defer d.Close()
+	}
+	if err == nil {
+		t.Fatal("expected 404-after-redirect to surface as error")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPStatusError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", httpErr.StatusCode)
+	}
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/pkg/warplib/manager.go
+++ b/pkg/warplib/manager.go
@@ -815,6 +815,41 @@ func (m *Manager) FlushOne(hash string) error {
 	return WarpRemoveAll(GetPath(DlDataDir, hash))
 }
 
+// PurgeFailedDownload removes a download entry that never wrote any
+// bytes. Unlike FlushOne it does NOT refuse items whose dAlloc pointer
+// is still set: an item that fails inside item.Start()/Resume() may
+// leave dAlloc populated even though the download never made progress,
+// and history hygiene requires we drop those rows anyway. Items that
+// downloaded any bytes (Downloaded > 0) are KEPT so the user can
+// resume — the caller is responsible for the Downloaded == 0 check.
+//
+// Returns nil if the hash isn't in the manager (idempotent — safe to
+// call from a generic error path even if the item was never added).
+func (m *Manager) PurgeFailedDownload(hash string) error {
+	if p := m.persister.Load(); p != nil {
+		if err := p.flush(); err != nil {
+			return fmt.Errorf("flush persister: %w", err)
+		}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	item, found := m.items[hash]
+	if !found {
+		return nil
+	}
+	delete(m.items, hash)
+	if err := m.persistItems(); err != nil {
+		// Restore on persist error to keep on-disk state consistent.
+		m.items[hash] = item
+		return fmt.Errorf("purge failed download: %w", err)
+	}
+	if err := m.f.Sync(); err != nil {
+		return fmt.Errorf("purge failed download sync: %w", err)
+	}
+	return WarpRemoveAll(GetPath(DlDataDir, hash))
+}
+
 // Close closes the manager safely, ensuring all data is persisted.
 // Safe to call multiple times and concurrently; only the first
 // caller performs the shutdown, others are no-ops.

--- a/pkg/warplib/start_error_log_test.go
+++ b/pkg/warplib/start_error_log_test.go
@@ -1,0 +1,118 @@
+package warplib
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression: when a queued download's Start() fails (e.g. target file
+// already exists on disk), the user had no per-download log entry to
+// explain why. Before this fix logs.txt contained only the init lines
+// (GET:, CONTENT-LENGTH:, FILE-NAME:) and the caller had to chase the
+// daemon console to find the error. Now Start() records the failure
+// via d.Log, so `cat dldata/<hash>/logs.txt` always tells the story.
+func TestStartLogsOpenFileFailureToLogsTxt(t *testing.T) {
+	body := []byte("some file content that would normally download")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "46")
+		w.Header().Set("Content-Disposition", `attachment; filename="already.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	// Redirect DlDataDir so this test's segment/log directories live in
+	// a temp path that t.TempDir will clean up.
+	orig := DlDataDir
+	DlDataDir = t.TempDir()
+	defer func() { DlDataDir = orig }()
+
+	downloadDir := t.TempDir()
+	// Pre-create the destination so openFile returns ErrFileExists.
+	collidePath := filepath.Join(downloadDir, "already.bin")
+	if err := os.WriteFile(collidePath, []byte("existing"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: downloadDir,
+		// LockFileName=true forces strict-collision behaviour (user
+		// explicitly chose this name; do NOT silently auto-rename).
+		// Without this flag the downloader would land on
+		// "already (1).bin" and Start() would succeed — a separate
+		// regression covered by uniquify_test.go.
+		FileName:     "already.bin",
+		LockFileName: true,
+		Overwrite:    false,
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+
+	startErr := d.Start()
+	if startErr == nil {
+		t.Fatal("expected Start to fail when destination exists and Overwrite=false")
+	}
+	if !strings.Contains(startErr.Error(), "already exists") {
+		t.Fatalf("unexpected Start error: %v", startErr)
+	}
+
+	// Critical assertion: logs.txt must contain the failure.
+	logsPath := filepath.Join(DlDataDir, d.GetHash(), "logs.txt")
+	data, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read logs.txt: %v", err)
+	}
+	if !strings.Contains(string(data), "Start failed") {
+		t.Errorf("logs.txt missing Start failed entry:\n%s", data)
+	}
+	if !strings.Contains(string(data), "already exists") {
+		t.Errorf("logs.txt missing underlying error:\n%s", data)
+	}
+}
+
+// A successful download must NOT leave a "Start failed" entry in
+// logs.txt — regression guard against accidentally logging errors on
+// the happy path.
+func TestStartLogsNoFailureOnSuccess(t *testing.T) {
+	body := []byte("hello world")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Range"), "bytes=") {
+			// Serve the range — warpdl will issue ranged requests for
+			// the segmented download. Keep it simple: return the whole body.
+			w.Header().Set("Content-Range", "bytes 0-10/11")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(body)
+			return
+		}
+		w.Header().Set("Content-Length", "11")
+		w.Header().Set("Content-Disposition", `attachment; filename="ok.txt"`)
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	orig := DlDataDir
+	DlDataDir = t.TempDir()
+	defer func() { DlDataDir = orig }()
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: t.TempDir(),
+		MaxConnections:    1,
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if err := d.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(DlDataDir, d.GetHash(), "logs.txt"))
+	if strings.Contains(string(data), "Start failed") {
+		t.Errorf("happy-path logs.txt contains Start failed:\n%s", data)
+	}
+}

--- a/pkg/warplib/uniquify.go
+++ b/pkg/warplib/uniquify.go
@@ -1,0 +1,72 @@
+package warplib
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxUniquifyAttempts caps how many " (N)" candidates we'll probe
+// before giving up. Bounds runtime in pathological cases (e.g. a
+// directory hand-crammed with `name (1).ext` … `name (1000).ext`)
+// and prevents an infinite loop if Stat keeps reporting "exists" due
+// to a permission error.
+const maxUniquifyAttempts = 4096
+
+// uniquifyPath returns a non-colliding sibling path under the same
+// directory as path. If path doesn't exist, returns it unchanged.
+// Otherwise inserts " (N)" before the file extension, picking the
+// smallest N >= 1 that doesn't already exist on disk — same convention
+// browsers use for the Save-As dialog.
+//
+// Examples:
+//   /tmp/report.pdf       (exists) -> /tmp/report (1).pdf
+//   /tmp/report (1).pdf   (exists) -> /tmp/report (2).pdf
+//   /tmp/Makefile         (exists) -> /tmp/Makefile (1)
+//   /tmp/archive.tar.gz   (exists) -> /tmp/archive.tar (1).gz
+//
+// The last extension is treated as the extension (Chrome/Firefox-ish);
+// this matches applyTimestampSuffix so naming is consistent.
+//
+// Returns an error if either Stat fails for a non-ENOENT reason or
+// every candidate up to maxUniquifyAttempts already exists.
+func uniquifyPath(path string) (string, error) {
+	exists, err := pathExists(path)
+	if err != nil {
+		return "", fmt.Errorf("uniquify: stat %s: %w", path, err)
+	}
+	if !exists {
+		return path, nil
+	}
+	dir := filepath.Dir(path)
+	leaf := filepath.Base(path)
+	ext := filepath.Ext(leaf)
+	base := strings.TrimSuffix(leaf, ext)
+	for n := 1; n < maxUniquifyAttempts; n++ {
+		candidate := filepath.Join(dir, fmt.Sprintf("%s (%d)%s", base, n, ext))
+		exists, err := pathExists(candidate)
+		if err != nil {
+			return "", fmt.Errorf("uniquify: stat %s: %w", candidate, err)
+		}
+		if !exists {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("uniquify: too many collisions for %s", path)
+}
+
+// pathExists is os.Stat that distinguishes "doesn't exist" from a real
+// error. Returns (false, nil) for ENOENT, (true, nil) for present,
+// (false, err) for anything else (permissions, I/O, etc.).
+func pathExists(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/warplib/uniquify_test.go
+++ b/pkg/warplib/uniquify_test.go
@@ -1,0 +1,248 @@
+package warplib
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUniquifyPath_NoCollisionReturnsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fresh.txt")
+	got, err := uniquifyPath(path)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != path {
+		t.Errorf("got %q, want %q (no collision => unchanged)", got, path)
+	}
+}
+
+func TestUniquifyPath_FirstCollisionInsertsParen1(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := uniquifyPath(path)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := filepath.Join(dir, "report (1).pdf")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUniquifyPath_SecondCollisionAdvancesCounter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.pdf")
+	for _, p := range []string{
+		path,
+		filepath.Join(dir, "report (1).pdf"),
+		filepath.Join(dir, "report (2).pdf"),
+	} {
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := uniquifyPath(path)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := filepath.Join(dir, "report (3).pdf")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUniquifyPath_NoExtension(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Makefile")
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := uniquifyPath(path)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := filepath.Join(dir, "Makefile (1)")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUniquifyPath_LastExtensionOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archive.tar.gz")
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := uniquifyPath(path)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// Chrome convention: only the last ".gz" is treated as extension.
+	want := filepath.Join(dir, "archive.tar (1).gz")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestUniquifyPath_TooManyCollisions(t *testing.T) {
+	dir := t.TempDir()
+	base := "swarm.bin"
+	if err := os.WriteFile(filepath.Join(dir, base), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for n := 1; n < maxUniquifyAttempts; n++ {
+		f := filepath.Join(dir, "swarm ("+itoa(n)+").bin")
+		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := uniquifyPath(filepath.Join(dir, base))
+	if err == nil {
+		t.Fatal("expected error after exhausting attempts")
+	}
+	if !strings.Contains(err.Error(), "too many collisions") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Integration: NewDownloader without LockFileName auto-renames when the
+// destination already exists. Reproduces the user's "1Ton1...identifier"
+// scenario in miniature: the prior failed attempt left a stub file at
+// the same path; the new download must land on `name (1).bin` instead
+// of erroring with ErrFileExists.
+func TestNewDownloader_AutoRenameOnCollision(t *testing.T) {
+	body := []byte("hello content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "13")
+		w.Header().Set("Content-Disposition", `attachment; filename="x.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	orig := DlDataDir
+	DlDataDir = t.TempDir()
+	defer func() { DlDataDir = orig }()
+
+	dlDir := t.TempDir()
+	stub := filepath.Join(dlDir, "x.bin")
+	if err := os.WriteFile(stub, []byte("stub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: dlDir,
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if d.GetFileName() != "x (1).bin" {
+		t.Errorf("filename = %q, want %q (auto-rename)", d.GetFileName(), "x (1).bin")
+	}
+	if !strings.HasSuffix(d.GetSavePath(), "x (1).bin") {
+		t.Errorf("save path %q does not end with renamed leaf", d.GetSavePath())
+	}
+}
+
+// LockFileName preserves the prior strict behaviour: a user who passed
+// --filename foo.bin gets ErrFileExists on collision rather than a
+// silent rename.
+func TestNewDownloader_LockFileNameKeepsStrictCollision(t *testing.T) {
+	body := []byte("hello content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "13")
+		w.Header().Set("Content-Disposition", `attachment; filename="ignored.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	orig := DlDataDir
+	DlDataDir = t.TempDir()
+	defer func() { DlDataDir = orig }()
+
+	dlDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dlDir, "user.bin"), []byte("stub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: dlDir,
+		FileName:          "user.bin",
+		LockFileName:      true,
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if d.GetFileName() != "user.bin" {
+		t.Errorf("filename = %q, want %q (locked)", d.GetFileName(), "user.bin")
+	}
+	startErr := d.Start()
+	if startErr == nil {
+		t.Fatal("expected ErrFileExists when LockFileName=true and dest exists")
+	}
+	if !errors.Is(startErr, ErrFileExists) {
+		t.Errorf("unexpected error: %v", startErr)
+	}
+}
+
+// Overwrite=true bypasses uniquify regardless of LockFileName.
+func TestNewDownloader_OverwriteSkipsUniquify(t *testing.T) {
+	body := []byte("hello content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "13")
+		w.Header().Set("Content-Disposition", `attachment; filename="x.bin"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	orig := DlDataDir
+	DlDataDir = t.TempDir()
+	defer func() { DlDataDir = orig }()
+
+	dlDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dlDir, "x.bin"), []byte("stub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := NewDownloader(srv.Client(), srv.URL, &DownloaderOpts{
+		DownloadDirectory: dlDir,
+		Overwrite:         true,
+	})
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if d.GetFileName() != "x.bin" {
+		t.Errorf("Overwrite=true should keep original name; got %q", d.GetFileName())
+	}
+}
+
+// Tiny itoa to avoid importing strconv just for the stress helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := []byte{}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	if neg {
+		buf = append([]byte{'-'}, buf...)
+	}
+	return string(buf)
+}


### PR DESCRIPTION
## Summary

Follow-up to #158. A pile of small fixes the v1 plugin-oauth design didn't anticipate — every one was caught by trying to actually download a private Google Drive file end-to-end with the gdrive plugin.

### OAuth manifest
- **Allow optional `client_secret`.** Google's Desktop-app OAuth client type requires `client_secret` on `/token` even when the flow is PKCE (the secret is embedded in the distributed plugin and provides no confidentiality). v1 rejected the field outright based on the wrong assumption that PKCE-only worked everywhere — first real-world test failed with `400 Bad Request: invalid_request: client_secret is missing`. Pure-PKCE plugins still work unchanged (leave the field empty).

### Plugin Extract contract
- **`ExtractResult.FileName` hint.** Drive's `?alt=media` endpoint streams bytes without `Content-Disposition`, so warpdl was deriving the filename from the URL path (= the opaque `fileId`, e.g. `1Ton1_wa2aGBAsXUjCignRXj1NVax2FeG`). Plugins can now resolve a real name (gdrive does so via `/files/<id>?fields=name`) and pass it through. Non-string filenames are rejected.

### HTTP status guard
- **`fetchInfo` now bails on 4xx/5xx** with `*HTTPStatusError`, including a trimmed body excerpt. Previously a `403 application/json` from Drive ("Drive API not enabled") was treated as a 2 KB file and saved to disk verbatim.

### Filename collision auto-rename
- **Browser-style `(1) (2) (n)`.** When the dest path already exists and the user did NOT pass `--filename`, warpdl picks `name (1).ext` instead of erroring. `LockFileName=true` (set by the daemon when the user explicitly specified `--filename`) preserves the prior strict `ErrFileExists` behaviour.

### Async-error visibility (no more silent fails)
- **`Downloader.Start/Resume` log every failure path** to the per-download `logs.txt` via a defer — so `cat dldata/<hash>/logs.txt` tells the same story as the daemon console.
- **Queue auto-start and scheduler trigger failures broadcast** `InitError` + critical error + `StopDownload` through the pool; a connected CLI sees an immediate error instead of polling at 0 B/s forever.
- `server.Server.Pool()` exposed so async-path code outside `internal/api` can plumb errors back to the CLI.

### History hygiene
- **`api.ReportAsyncDownloadError(pool, uid, err, mgr)`** — when `mgr` is non-nil and `item.Downloaded == 0` the entry is purged via the new `Manager.PurgeFailedDownload`. Mid-download failures (`Downloaded > 0`) are kept so the user can resume. `PurgeFailedDownload` is distinct from `FlushOne` in that it doesn't refuse items whose `dAlloc` pointer is still set.

### Submodule
- `contrib/` bumped to [`warpdl/contrib@5f4a57c`](https://github.com/warpdl/contrib/commit/5f4a57c) (gdrive plugin updated to use the new contract).

## Test plan
- [x] `go test ./pkg/warplib/... ./internal/extl/... ./internal/api/... ./internal/server/... ./contrib/plugins/gdrive/... ./cmd/...` — all green
- [x] Real-world: `warp auth login gdrive` → browser PKCE + client_secret → token issued → `warp download <private_drive_url>` → 24 MB mkv saved with the right human-readable filename (the user's own .mkv that prompted this PR)
- [x] Pre-existing collision: stale stub at dest → next download lands on `name (1).ext` instead of erroring
- [x] Failed download → no longer pollutes `warp list` history
- [x] CLI no longer hangs on 0 B/s when daemon-side queue refuses to start

## New tests (~25 added)
| Area | Coverage |
|---|---|
| OAuth (`internal/extl/auth`) | client_secret on auth-code/refresh/device-code; preservation of caller-set value; manifest validator accepts optional |
| Module (`internal/extl`) | FileName accepted, optional, non-string rejected |
| Async error (`internal/api`) | broadcasts/records/stops; purges zero-byte; keeps partial |
| HTTP status (`pkg/warplib`) | 4xx with snippet; truncation; after-redirect; 2xx unchanged |
| Auto-rename (`pkg/warplib`) | no-ext, last-ext-only, advancing counter, max-attempts; LockFileName strict |
| Start/Resume logs | failure recorded to logs.txt; happy path quiet |
| gdrive plugin | authenticated path bypasses /uc + fetches name; metadata-fetch failure degrades gracefully; malformed JSON safe; no-account path unchanged |