### PR TITLE
test: raise coverage to 80%+

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -87,11 +87,11 @@ func authLogin(ctx *cli.Context) error {
 	// that a caller may have passed through StringSlice.
 	scopes := append([]string(nil), ctx.StringSlice("scopes")...)
 
-	client, err := getClient()
+	client, close, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer client.Close()
+	defer close()
 
 	if ctx.Bool("device") {
 		return runDeviceFlow(ctx.App.Writer, client, pluginID, account, scopes)
@@ -112,6 +112,16 @@ type authRPC interface {
 
 // compile-time check: the concrete client must satisfy the interface.
 var _ authRPC = (*warpcli.Client)(nil)
+
+// authClientFactory dials the daemon for auth subcommands. Tests replace it
+// to avoid a live daemon socket.
+var authClientFactory = func() (client authRPC, close func(), err error) {
+	c, err := getClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, func() { _ = c.Close() }, nil
+}
 
 // HandleAuthRequired runs the interactive auth orchestrator in response
 // to a daemon-pushed UPDATE_AUTH_REQUIRED event received while the CLI
@@ -495,11 +505,11 @@ func authListCmd() cli.Command {
 // credentials via the daemon and prints them; an empty store prints a
 // friendly "No stored credentials." message instead of an empty table.
 func authList(ctx *cli.Context) error {
-	client, err := getClient()
+	client, close, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer client.Close()
+	defer close()
 	res, err := client.AuthList()
 	if err != nil {
 		return fmt.Errorf("auth.list: %w", err)
@@ -566,11 +576,11 @@ func authLogout(ctx *cli.Context) error {
 	if account == "" {
 		account = "default"
 	}
-	client, err := getClient()
+	client, close, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer client.Close()
+	defer close()
 	if err := client.AuthLogout(&common.AuthLogoutParams{
 		PluginID: pluginID,
 		Account:  account,
@@ -615,11 +625,11 @@ func authStatus(ctx *cli.Context) error {
 	if account == "" {
 		account = "default"
 	}
-	client, err := getClient()
+	client, close, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer client.Close()
+	defer close()
 	res, err := client.AuthList()
 	if err != nil {
 		return fmt.Errorf("auth.list: %w", err)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -87,11 +87,11 @@ func authLogin(ctx *cli.Context) error {
 	// that a caller may have passed through StringSlice.
 	scopes := append([]string(nil), ctx.StringSlice("scopes")...)
 
-	client, close, err := authClientFactory()
+	client, closeFn, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer close()
+	defer closeFn()
 
 	if ctx.Bool("device") {
 		return runDeviceFlow(ctx.App.Writer, client, pluginID, account, scopes)
@@ -115,7 +115,7 @@ var _ authRPC = (*warpcli.Client)(nil)
 
 // authClientFactory dials the daemon for auth subcommands. Tests replace it
 // to avoid a live daemon socket.
-var authClientFactory = func() (client authRPC, close func(), err error) {
+var authClientFactory = func() (client authRPC, closeFn func(), err error) {
 	c, err := getClient()
 	if err != nil {
 		return nil, nil, err
@@ -505,11 +505,11 @@ func authListCmd() cli.Command {
 // credentials via the daemon and prints them; an empty store prints a
 // friendly "No stored credentials." message instead of an empty table.
 func authList(ctx *cli.Context) error {
-	client, close, err := authClientFactory()
+	client, closeFn, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer close()
+	defer closeFn()
 	res, err := client.AuthList()
 	if err != nil {
 		return fmt.Errorf("auth.list: %w", err)
@@ -576,11 +576,11 @@ func authLogout(ctx *cli.Context) error {
 	if account == "" {
 		account = "default"
 	}
-	client, close, err := authClientFactory()
+	client, closeFn, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer close()
+	defer closeFn()
 	if err := client.AuthLogout(&common.AuthLogoutParams{
 		PluginID: pluginID,
 		Account:  account,
@@ -625,11 +625,11 @@ func authStatus(ctx *cli.Context) error {
 	if account == "" {
 		account = "default"
 	}
-	client, close, err := authClientFactory()
+	client, closeFn, err := authClientFactory()
 	if err != nil {
 		return fmt.Errorf("connect daemon: %w", err)
 	}
-	defer close()
+	defer closeFn()
 	res, err := client.AuthList()
 	if err != nil {
 		return fmt.Errorf("auth.list: %w", err)

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -98,6 +98,10 @@ func newAuthLoginContext(args []string, flagVals map[string]string) *cli.Context
 	// Inject flag values first, then positional args.
 	rawArgs := []string{}
 	for k, v := range flagVals {
+		if v == "true" {
+			rawArgs = append(rawArgs, "--"+k)
+			continue
+		}
 		rawArgs = append(rawArgs, "--"+k, v)
 	}
 	rawArgs = append(rawArgs, args...)
@@ -192,6 +196,113 @@ func TestAuthCmdShape(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("subcommand \"login\" missing")
+	}
+}
+
+func withFakeAuthClient(t *testing.T, fake *fakeAuthRPC) {
+	t.Helper()
+	prev := authClientFactory
+	authClientFactory = func() (authRPC, func(), error) {
+		return fake, func() {}, nil
+	}
+	t.Cleanup(func() { authClientFactory = prev })
+}
+
+// TestAuthList prints stored credentials via authList.
+func TestAuthList(t *testing.T) {
+	fake := &fakeAuthRPC{
+		listRes: &common.AuthListResult{Accounts: []common.AuthAccount{
+			{PluginID: "gdrive", Account: "default", Scopes: []string{"read"}, ExpiresAt: time.Now().Add(time.Hour).Unix()},
+		}},
+	}
+	withFakeAuthClient(t, fake)
+	app := cli.NewApp()
+	app.Writer = io.Discard
+	ctx := cli.NewContext(app, flag.NewFlagSet("list", flag.ContinueOnError), nil)
+	ctx.Command = authListCmd()
+	var buf bytes.Buffer
+	ctx.App.Writer = &buf
+	if err := authList(ctx); err != nil {
+		t.Fatalf("authList: %v", err)
+	}
+	if !strings.Contains(buf.String(), "gdrive") {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
+// TestAuthListEmpty prints the friendly empty-store message.
+func TestAuthListEmpty(t *testing.T) {
+	fake := &fakeAuthRPC{listRes: &common.AuthListResult{}}
+	withFakeAuthClient(t, fake)
+	app := cli.NewApp()
+	var buf bytes.Buffer
+	ctx := cli.NewContext(app, flag.NewFlagSet("list", flag.ContinueOnError), nil)
+	ctx.Command = authListCmd()
+	ctx.App.Writer = &buf
+	if err := authList(ctx); err != nil {
+		t.Fatalf("authList: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No stored credentials") {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
+// TestAuthLogoutSuccess issues auth.logout for the target plugin.
+func TestAuthLogoutSuccess(t *testing.T) {
+	fake := &fakeAuthRPC{}
+	withFakeAuthClient(t, fake)
+	ctx := newAuthActionContext(authLogoutCmd(), []string{"gdrive"}, nil)
+	var buf bytes.Buffer
+	ctx.App.Writer = &buf
+	if err := authLogout(ctx); err != nil {
+		t.Fatalf("authLogout: %v", err)
+	}
+	if len(fake.logoutCalls) != 1 || fake.logoutCalls[0].PluginID != "gdrive" {
+		t.Fatalf("logoutCalls = %+v", fake.logoutCalls)
+	}
+}
+
+// TestAuthStatusViaAction exercises authStatus exit code 0.
+func TestAuthStatusViaAction(t *testing.T) {
+	fake := &fakeAuthRPC{
+		listRes: &common.AuthListResult{Accounts: []common.AuthAccount{
+			{PluginID: "gdrive", Account: "default", ExpiresAt: time.Now().Add(time.Hour).Unix()},
+		}},
+	}
+	withFakeAuthClient(t, fake)
+	ctx := newAuthActionContext(authStatusCmd(), []string{"gdrive"}, nil)
+	var buf bytes.Buffer
+	ctx.App.Writer = &buf
+	if err := authStatus(ctx); err != nil {
+		t.Fatalf("authStatus: %v", err)
+	}
+	if !strings.Contains(buf.String(), "authenticated") {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
+// TestAuthLoginDevice dispatches to the device flow when --device is set.
+func TestAuthLoginDevice(t *testing.T) {
+	fake := &fakeAuthRPC{
+		loginRes: &common.AuthLoginResult{
+			FlowID:          "f",
+			VerificationURL: "https://example.com/v",
+			UserCode:        "CODE",
+			Interval:        1,
+		},
+		listRes: &common.AuthListResult{Accounts: []common.AuthAccount{
+			{PluginID: "plug", Account: "acct"},
+		}},
+	}
+	withFakeAuthClient(t, fake)
+	ctx := newAuthLoginContext([]string{"plug"}, map[string]string{"device": "true", "as": "acct"})
+	var buf bytes.Buffer
+	ctx.App.Writer = &buf
+	if err := authLogin(ctx); err != nil {
+		t.Fatalf("authLogin: %v", err)
+	}
+	if len(fake.loginCalls) != 1 || fake.loginCalls[0].Flow != "device" {
+		t.Fatalf("loginCalls = %+v", fake.loginCalls)
 	}
 }
 
@@ -423,6 +534,84 @@ func TestRunPKCEFlow_LoginFailure(t *testing.T) {
 	}
 	if len(fake.loginCalls) != 1 {
 		t.Fatalf("login calls = %d", len(fake.loginCalls))
+	}
+}
+
+// TestRunPKCEFlow_Success drives the happy path: loopback server receives
+// the OAuth callback and runPKCEFlow returns without error.
+func TestRunPKCEFlow_Success(t *testing.T) {
+	fake := &fakeAuthRPC{
+		loginRes: &common.AuthLoginResult{
+			FlowID:       "flow-ok",
+			AuthorizeURL: "http://127.0.0.1:1/callback", // overwritten by printed URL
+		},
+		completeRes: &common.AuthCompleteResult{Account: "default"},
+	}
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- runPKCEFlow(&buf, fake, "plugin", "default", nil, true)
+	}()
+
+	var redirect string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		fake.mu.Lock()
+		if len(fake.loginCalls) > 0 {
+			redirect = fake.loginCalls[0].RedirectURI
+		}
+		fake.mu.Unlock()
+		if redirect != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if redirect == "" {
+		t.Fatal("runPKCEFlow did not call AuthLogin")
+	}
+
+	resp, err := http.Get(redirect + "?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runPKCEFlow: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runPKCEFlow did not finish")
+	}
+	if !strings.Contains(buf.String(), "Logged in") {
+		t.Fatalf("output = %q", buf.String())
+	}
+	if len(fake.completeCalls) != 1 || fake.completeCalls[0].FlowID != "flow-ok" {
+		t.Fatalf("completeCalls = %+v", fake.completeCalls)
+	}
+}
+
+// TestRunDeviceFlow_Success exits when auth.list reports the target account.
+func TestRunDeviceFlow_Success(t *testing.T) {
+	fake := &fakeAuthRPC{
+		loginRes: &common.AuthLoginResult{
+			FlowID:          "flow-dev",
+			VerificationURL: "https://example.com/device",
+			UserCode:        "ABCD-1234",
+			Interval:        1,
+		},
+		listRes: &common.AuthListResult{Accounts: []common.AuthAccount{
+			{PluginID: "plug", Account: "acct"},
+		}},
+	}
+	var buf bytes.Buffer
+	err := runDeviceFlow(&buf, fake, "plug", "acct", []string{"read"})
+	if err != nil {
+		t.Fatalf("runDeviceFlow: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Logged in") {
+		t.Fatalf("output = %q", buf.String())
 	}
 }
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -61,11 +61,10 @@ func downloadComplete(client *warpcli.Client, dbar, cbar *mpb.Bar, sc *SpeedCoun
 			return nil
 		}
 		dbar.SetCurrent(dr.Value)
-		// fill compile bar
-		if cbar.Completed() {
-			return nil
-		}
-		cbar.SetCurrent(dr.Value)
+		// Do not touch the compile bar here: it may still be queued via
+		// BarQueueAfter and has no serving goroutine until the download bar
+		// finishes. compileProgress / compileComplete update it later.
+		_ = cbar
 		return nil
 	}
 }

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -118,11 +118,9 @@ func TestDownloadComplete_BothBarsCompleted(t *testing.T) {
 		t.Fatalf("downloadComplete with both bars completed: %v", err)
 	}
 
-	// Verify bars are still completed and current values weren't changed
+	// Verify download bar stayed completed; compile bar is not touched by
+	// downloadComplete when the download bar is already done.
 	if !dbar.Completed() {
 		t.Error("expected download bar to remain completed")
-	}
-	if !cbar.Completed() {
-		t.Error("expected compile bar to remain completed")
 	}
 }

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -51,7 +51,10 @@ func InitBars(p *mpb.Progress, prefix string, cLength int64) (dbar *mpb.Bar, cba
 
 	name := prefix + "Downloading"
 
-	dbar = p.New(0,
+	// Pass total in New so triggerComplete is enabled without SetTotal.
+	// Do not call SetTotal/EnableTriggerComplete on a BarQueueAfter bar before
+	// its wait bar finishes — the queued bar's serve goroutine is not running yet.
+	dbar = p.New(cLength,
 		barStyle,
 		mpb.PrependDecorators(
 			decor.Name(name, decor.WC{W: len(name) + 1, C: decor.DindentRight}),
@@ -63,11 +66,13 @@ func InitBars(p *mpb.Progress, prefix string, cLength int64) (dbar *mpb.Bar, cba
 			decor.EwmaSpeed(decor.SizeB1024(0), "% .2f", 30),
 		),
 	)
-	dbar.SetTotal(cLength, false)
-	dbar.EnableTriggerComplete()
+	if cLength <= 0 {
+		dbar.SetTotal(cLength, false)
+		dbar.EnableTriggerComplete()
+	}
 
 	name = prefix + "Compiling"
-	cbar = p.New(0,
+	cbar = p.New(cLength,
 		barStyle,
 		mpb.BarQueueAfter(dbar),
 		mpb.PrependDecorators(
@@ -80,8 +85,6 @@ func InitBars(p *mpb.Progress, prefix string, cLength int64) (dbar *mpb.Bar, cba
 			decor.AverageSpeed(decor.SizeB1024(0), "% .2f"),
 		),
 	)
-	cbar.SetTotal(cLength, false)
-	cbar.EnableTriggerComplete()
 	return
 }
 

--- a/cmd/download_batch_test.go
+++ b/cmd/download_batch_test.go
@@ -50,7 +50,7 @@ func (m *MockClient) Close() error {
 func TestDownloadBatchFromFile_Background(t *testing.T) {
 	content := "https://example.com/a.zip\n"
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	socketPath := getShortSocketPath(t)
 	t.Setenv("WARPDL_SOCKET_PATH", socketPath)
@@ -89,7 +89,7 @@ func TestDownloadBatch_TwoURLsFromFile(t *testing.T) {
 	content := `https://example.com/file1.zip
 https://example.com/file2.tar.gz`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	mock := &MockClient{}
 
@@ -119,7 +119,7 @@ func TestDownloadBatch_MixFileAndDirectURLs(t *testing.T) {
 	// Create input file with 1 URL
 	content := `https://example.com/file1.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	mock := &MockClient{}
 
@@ -152,7 +152,7 @@ func TestDownloadBatch_ContinueOnError(t *testing.T) {
 https://example.com/fail.zip
 https://example.com/file3.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	// Mock client that fails on specific URL
 	mock := &MockClient{
@@ -198,7 +198,7 @@ func TestDownloadBatch_EmptyFile(t *testing.T) {
 	// Create empty input file
 	content := ``
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	mock := &MockClient{}
 
@@ -498,7 +498,7 @@ ftp://example.com/invalid.zip
 https://example.com/file2.zip
 magnet:?xt=urn:btih:abc123`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	mock := &MockClient{}
 
@@ -556,7 +556,7 @@ func TestDownloadBatch_AllFail(t *testing.T) {
 https://example.com/fail2.zip
 https://example.com/fail3.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	// Mock client that fails every download
 	mock := &MockClient{
@@ -609,7 +609,7 @@ https://example.com/fail3.zip`
 func TestDownloadBatch_AllSucceed_LargeFile(t *testing.T) {
 	content := "https://example.com/file0.zip\nhttps://example.com/file1.zip\nhttps://example.com/file2.zip\nhttps://example.com/file3.zip\nhttps://example.com/file4.zip\nhttps://example.com/file5.zip\nhttps://example.com/file6.zip\nhttps://example.com/file7.zip\nhttps://example.com/file8.zip\nhttps://example.com/file9.zip"
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	mock := &MockClient{}
 
@@ -646,7 +646,7 @@ func TestDownloadBatch_MixedFailures_FileAndDirect(t *testing.T) {
 	content := `https://example.com/file-ok.zip
 https://example.com/file-fail.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	// Direct URLs: one ok, one fail
 	directURLs := []string{
@@ -706,7 +706,7 @@ https://example.com/file-fail.zip`
 func TestDownloadBatch_DownloadOptsPassedThrough(t *testing.T) {
 	content := `https://example.com/file.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	// Create download options with custom settings
 	downloadOpts := &warpcli.DownloadOpts{
@@ -808,7 +808,7 @@ https://example.com/notfound.zip
 https://example.com/forbidden.zip
 https://example.com/success.zip`
 	tmpFile := createTempInputFile(t, content)
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	// Mock different error types for different URLs
 	mock := &MockClient{

--- a/cmd/download_batch_test.go
+++ b/cmd/download_batch_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"errors"
+	"flag"
 	"os"
 	"testing"
 
+	"github.com/urfave/cli"
 	"github.com/warpdl/warpdl/common"
 	"github.com/warpdl/warpdl/pkg/warpcli"
 )
@@ -43,6 +45,43 @@ func (m *MockClient) Download(url, fileName, dir string, opts *warpcli.DownloadO
 
 func (m *MockClient) Close() error {
 	return nil
+}
+
+func TestDownloadBatchFromFile_Background(t *testing.T) {
+	content := "https://example.com/a.zip\n"
+	tmpFile := createTempInputFile(t, content)
+	defer os.Remove(tmpFile)
+
+	socketPath := getShortSocketPath(t)
+	t.Setenv("WARPDL_SOCKET_PATH", socketPath)
+	srv := startFakeServer(t, socketPath)
+	defer srv.close()
+
+	app := cli.NewApp()
+	set := flag.NewFlagSet("download", flag.ContinueOnError)
+	for _, f := range dlFlags {
+		f.Apply(set)
+	}
+	_ = set.Parse([]string{"--background", "-input-file", tmpFile})
+	ctx := cli.NewContext(app, set, nil)
+	ctx.Command = cli.Command{Name: "download", Flags: dlFlags}
+	if !ctx.Bool("background") {
+		t.Fatal("expected --background flag to be set")
+	}
+
+	oldDlPath := dlPath
+	dlPath = t.TempDir()
+	defer func() { dlPath = oldDlPath }()
+
+	client, err := getClient()
+	if err != nil {
+		t.Fatalf("getClient: %v", err)
+	}
+
+	if err := downloadBatchFromFile(ctx, client, tmpFile); err != nil {
+		t.Fatalf("downloadBatchFromFile: %v", err)
+	}
+	_ = client.Close()
 }
 
 func TestDownloadBatch_TwoURLsFromFile(t *testing.T) {

--- a/internal/extl/auth/bindings_test.go
+++ b/internal/extl/auth/bindings_test.go
@@ -38,6 +38,39 @@ func setupRuntime(t *testing.T) (*goja.Runtime, *OAuth2Provider, *credman.TokenM
 	return rt, p, tm
 }
 
+func TestParseOpts(t *testing.T) {
+	rt := goja.New()
+	acc, scopes, err := parseOpts(rt, goja.Undefined())
+	if err != nil || acc != "" || scopes != nil {
+		t.Fatalf("undefined: acc=%q scopes=%v err=%v", acc, scopes, err)
+	}
+	v, err := rt.RunString(`({account: "work", scopes: ["a","b"]})`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acc, scopes, err = parseOpts(rt, v)
+	if err != nil || acc != "work" || len(scopes) != 2 {
+		t.Fatalf("object: acc=%q scopes=%v err=%v", acc, scopes, err)
+	}
+	if _, _, err := parseOpts(rt, rt.ToValue("nope")); err == nil {
+		t.Fatal("expected error for non-object options")
+	}
+	v, err = rt.RunString(`({scopes: 123})`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := parseOpts(rt, v); err == nil {
+		t.Fatal("expected error for non-string-array scopes")
+	}
+}
+
+func TestBindingFetchWithAuthRequiresRequest(t *testing.T) {
+	rt, _, _ := setupRuntime(t)
+	if _, err := rt.RunString(`fetchWithAuth({url: "https://example.com"}, {})`); err == nil {
+		t.Fatal("expected error when request() is not installed")
+	}
+}
+
 func TestBindingGetAccessTokenReturnsString(t *testing.T) {
 	rt, _, tm := setupRuntime(t)
 	k := types.TokenKey{PluginID: "pid", Account: "default"}

--- a/internal/extl/auth/flowregistry_test.go
+++ b/internal/extl/auth/flowregistry_test.go
@@ -134,6 +134,29 @@ func TestFlowRegistry_ResolvedFlowNotReusedByLaterStart(t *testing.T) {
 	}
 }
 
+func TestFlowRegistry_StartAfterShutdown(t *testing.T) {
+	fr := NewFlowRegistry(time.Minute)
+	fr.Shutdown()
+	_, _, err := fr.Start(types.TokenKey{PluginID: "p"}, FlowKindPKCE)
+	if !errors.Is(err, ErrRegistryShutDown) {
+		t.Fatalf("expected ErrRegistryShutDown, got %v", err)
+	}
+}
+
+func TestFlowRegistry_CancelNilError(t *testing.T) {
+	fr := NewFlowRegistry(time.Minute)
+	defer fr.Shutdown()
+	f, _, _ := fr.Start(types.TokenKey{PluginID: "p"}, FlowKindPKCE)
+	done := make(chan error, 1)
+	go func() { _, err := fr.Await(f.ID); done <- err }()
+	time.Sleep(10 * time.Millisecond)
+	fr.Cancel(f.ID, nil)
+	err := <-done
+	if err == nil || err.Error() != "cancelled" {
+		t.Fatalf("expected cancelled error, got %v", err)
+	}
+}
+
 func TestFlowRegistry_CancelReturnsError(t *testing.T) {
 	fr := NewFlowRegistry(time.Minute)
 	defer fr.Shutdown()

--- a/internal/extl/auth/oauth2_test.go
+++ b/internal/extl/auth/oauth2_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -644,6 +645,153 @@ func TestDeviceCodeGrantSendsClientSecretWhenConfigured(t *testing.T) {
 
 // A caller that has already set client_secret on the form (future-proof
 // against exotic grants) must not be overwritten by the manifest's value.
+func TestStartDeviceCodeUnsupported(t *testing.T) {
+	p, _ := makeTestProvider(t, "https://example.com/t", "")
+	p.cfg.DeviceURL = ""
+	if _, err := p.StartDeviceCode(context.Background()); err == nil {
+		t.Fatal("expected error when device flow is not configured")
+	}
+}
+
+func TestNewPKCEVerifier(t *testing.T) {
+	v, err := NewPKCEVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v) < 20 {
+		t.Fatalf("verifier too short: %q", v)
+	}
+}
+
+func TestResolveScopes(t *testing.T) {
+	t.Parallel()
+	if got := resolveScopes([]string{"a"}, []string{"x", "y"}); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("request scopes: got %v", got)
+	}
+	if got := resolveScopes(nil, []string{"x", "y"}); len(got) != 2 {
+		t.Fatalf("manifest scopes: got %v", got)
+	}
+}
+
+func TestTriggerFlowAndAwait_ImmediateCancel(t *testing.T) {
+	p, _ := makeTestProvider(t, "https://example.com/t", "")
+	tk := types.TokenKey{PluginID: "plugin-1"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := p.Token(ctx, tk, []string{"drive.readonly"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Token err = %v", err)
+	}
+}
+
+func TestTriggerFlowAndAwait_ResolveError(t *testing.T) {
+	p, _ := makeTestProvider(t, "https://example.com/t", "")
+	tk := types.TokenKey{PluginID: "plugin-1"}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		f, _, err := p.flows.Start(tk, FlowKindPKCE)
+		if err != nil || f == nil {
+			return
+		}
+		p.flows.Resolve(f.ID, nil, errors.New("auth denied"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := p.Token(ctx, tk, []string{"drive.readonly"})
+	if err == nil || !strings.Contains(err.Error(), "auth denied") {
+		t.Fatalf("Token err = %v", err)
+	}
+}
+
+func TestPollDeviceCodeSlowDown(t *testing.T) {
+	var polls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device/code", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code": "dev", "user_code": "X", "verification_url": "https://x", "interval": 1,
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		n := polls.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"slow_down"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "AT", "token_type": "Bearer", "expires_in": 3600,
+		})
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+	p, _ := makeTestProvider(t, srv.URL+"/token", "")
+	p.cfg.DeviceURL = srv.URL + "/device/code"
+	p.client = newInsecureTLSClient()
+	init, err := p.StartDeviceCode(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	tok, err := p.PollDeviceCode(ctx, init)
+	if err != nil || tok.AccessToken != "AT" {
+		t.Fatalf("PollDeviceCode: tok=%+v err=%v", tok, err)
+	}
+	if polls.Load() < 2 {
+		t.Fatalf("expected at least 2 token polls, got %d", polls.Load())
+	}
+}
+
+func TestStartDeviceCodeProviderError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device/code", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+	p, _ := makeTestProvider(t, srv.URL+"/token", "")
+	p.cfg.DeviceURL = srv.URL + "/device/code"
+	p.client = newInsecureTLSClient()
+	if _, err := p.StartDeviceCode(context.Background()); err == nil {
+		t.Fatal("expected provider error")
+	}
+}
+
+func TestTriggerFlowAndAwait_Success(t *testing.T) {
+	p, tm := makeTestProvider(t, "https://example.com/t", "")
+	tk := types.TokenKey{PluginID: "plugin-1"}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		f, _, err := p.flows.Start(tk, FlowKindPKCE)
+		if err != nil || f == nil {
+			return
+		}
+		p.flows.Resolve(f.ID, &types.OAuth2Token{
+			AccessToken: "fresh",
+			ExpiresAt:   time.Now().Add(time.Hour),
+			Scopes:      []string{"drive.readonly"},
+		}, nil)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	tok, err := p.Token(ctx, tk, []string{"drive.readonly"})
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "fresh" {
+		t.Fatalf("token = %q", tok)
+	}
+	stored, err := tm.Get(tk)
+	if err != nil || stored.AccessToken != "fresh" {
+		t.Fatalf("stored = %+v err=%v", stored, err)
+	}
+}
+
 func TestPostTokenPreservesExplicitClientSecret(t *testing.T) {
 	idp := newStubIdP(t, "AT", "", 3600)
 	p, _ := makeTestProviderWithSecret(t, idp.server.URL+"/token", "", "MANIFEST-SECRET")


### PR DESCRIPTION
## Summary
- Fix mpb progress bar deadlocks in `InitBars` (queued compile bar) and `downloadComplete` so `cmd` tests finish reliably instead of timing out.
- Add focused tests for auth flows, auth CLI actions, batch downloads, and `internal/extl/auth` OAuth helpers.
- Introduce `authClientFactory` so auth subcommands can be unit-tested without a live daemon.

## Test plan
- [x] `scripts/check_coverage.sh` (all packages ≥80%, total ~85.8%)
- [x] `go test ./...`
- [x] `go test -race -short ./...`


Made with [Cursor](https://cursor.com)